### PR TITLE
Player movement

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -1,0 +1,219 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3036084876555022737
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8927326740247510291}
+  - component: {fileID: 3633958285890614763}
+  - component: {fileID: 7873454966017981901}
+  - component: {fileID: 5001340343072802400}
+  - component: {fileID: 8731268012277226498}
+  m_Layer: 0
+  m_Name: Player
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8927326740247510291
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3036084876555022737}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.21, y: -3.73, z: 0}
+  m_LocalScale: {x: 0.6, y: 0.6, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6528851941878960290}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &3633958285890614763
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3036084876555022737}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 48e93eef0688c4a259cb0eddcd8661f7, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!50 &7873454966017981901
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3036084876555022737}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 1
+  m_SleepingMode: 0
+  m_CollisionDetection: 1
+  m_Constraints: 4
+--- !u!61 &5001340343072802400
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3036084876555022737}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!114 &8731268012277226498
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3036084876555022737}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 879ecf2afe6792543b653d9bd87af1b9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  inputManager: {fileID: 0}
+  playerSpeed: 3
+  maxSpeed: 4
+  maxAirSpeed: 2
+  jumpForce: 8
+  airMultiplier: 0.4
+  groundCheck: {fileID: 6528851941878960290}
+  groundLayer:
+    serializedVersion: 2
+    m_Bits: 64
+--- !u!1 &3551117260680316506
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6528851941878960290}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6528851941878960290
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3551117260680316506}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8927326740247510291}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Player.prefab.meta
+++ b/Assets/Prefabs/Player.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 37ec8a36ed0e820478599d184703667a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/InputManager.cs
+++ b/Assets/Scripts/InputManager.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+public class InputManager : MonoBehaviour
+{
+    // Start is called once before the first execution of Update after the MonoBehaviour is created
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/Scripts/InputManager.cs
+++ b/Assets/Scripts/InputManager.cs
@@ -1,16 +1,49 @@
 using UnityEngine;
+using UnityEngine.Events;
 
 public class InputManager : MonoBehaviour
 {
-    // Start is called once before the first execution of Update after the MonoBehaviour is created
-    void Start()
-    {
-        
-    }
+    [Header("Player One Keybinds")]
+    [SerializeField] private KeyCode playerOneLeft = KeyCode.A;
+    [SerializeField] private KeyCode playerOneRight = KeyCode.D;
+    [SerializeField] private KeyCode playerOneJump = KeyCode.W;
 
-    // Update is called once per frame
+    [Header("Player Two Keybinds")]
+    [SerializeField] private KeyCode playerTwoLeft = KeyCode.LeftArrow;
+    [SerializeField] private KeyCode playerTwoRight = KeyCode.RightArrow;
+    [SerializeField] private KeyCode playerTwoJump = KeyCode.UpArrow;
+
+    public UnityEvent<Vector2> playerOneOnMove = new UnityEvent<Vector2>();
+    public UnityEvent playerOneOnJumpEnd = new UnityEvent();
+    public UnityEvent playerOneOnJump = new UnityEvent();
+
+
     void Update()
     {
-        
+        Vector2 inputVector = new Vector2();
+
+        if (Input.GetKey(playerOneLeft))
+        {
+            inputVector += Vector2.left;
+        }
+
+        if (Input.GetKey(playerOneRight))
+        {
+            inputVector += Vector2.right;
+        }
+
+
+        playerOneOnMove?.Invoke(inputVector);
+
+        // there are two different jump events to handle a player holding vs tapping the jump button. allows for variable jump heights
+        if (Input.GetKeyDown(playerOneJump))
+        {
+            playerOneOnJump?.Invoke();
+        }
+        if (Input.GetKeyUp(playerOneJump))
+        {
+            playerOneOnJumpEnd?.Invoke();
+        }
+
     }
 }

--- a/Assets/Scripts/InputManager.cs.meta
+++ b/Assets/Scripts/InputManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ba26902b6d18a9949b842c561e548a60

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+public class NewMonoBehaviourScript : MonoBehaviour
+{
+    // Start is called once before the first execution of Update after the MonoBehaviour is created
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -1,16 +1,106 @@
 using UnityEngine;
 
-public class NewMonoBehaviourScript : MonoBehaviour
+public class PlayerMovement : MonoBehaviour
 {
-    // Start is called once before the first execution of Update after the MonoBehaviour is created
+    private Rigidbody2D rb;
+    [SerializeField] private InputManager inputManager;
+
+    private float horizontal;
+    private bool isFacingRight = true;
+
+    [Header("Movement")]
+    [SerializeField] private float playerSpeed;
+    [SerializeField] private float maxSpeed;
+    [SerializeField] private float maxAirSpeed;
+
+    [SerializeField] private float jumpForce;
+    [SerializeField] private float airMultiplier;
+
+    [Header("Ground Check")]
+    [SerializeField] private Transform groundCheck;
+    [SerializeField] private LayerMask groundLayer;
+
+
+    // add the listeners for the events that InputManager throws and get the rigidbody
     void Start()
     {
-        
+        inputManager.playerOneOnMove.AddListener(MovePlayer);
+        inputManager.playerOneOnJump.AddListener(Jump);
+        inputManager.playerOneOnJumpEnd.AddListener(JumpEnd);
+        rb = GetComponent<Rigidbody2D>();
     }
 
-    // Update is called once per frame
+    // update ensures that the player doesn't go above the speed limit and handles flipping the character for sprite stuff
     void Update()
     {
-        
+        SpeedControl();
+        Flip();
+    }
+
+    // adds force to the rigidbody to move the character. Applies a different speed if the character is in the air
+    public void MovePlayer(Vector2 input)
+    {
+        if (IsGrounded())
+            rb.AddForce(input.normalized * playerSpeed, ForceMode2D.Force);
+
+        else if (!IsGrounded())
+            rb.AddForce(input.normalized * playerSpeed * airMultiplier, ForceMode2D.Force);
+
+        horizontal = input.normalized.x;
+    }
+
+    // handles flipping the character
+    private void Flip()
+    {
+        if (isFacingRight && horizontal < 0f || !isFacingRight && horizontal > 0f)
+        {
+            isFacingRight = !isFacingRight;
+            Vector3 localScale = transform.localScale;
+            localScale.x *= -1f;
+            transform.localScale = localScale;
+        }
+    }
+
+    // checks if the player is on the ground by using the OverlapCircle method. the groundLayer should be the ground tag in the game
+    private bool IsGrounded()
+    {
+        return Physics2D.OverlapCircle(groundCheck.position, 0.2f, groundLayer);
+    }
+
+    // handles jumps. makes the y component equal to the jump force
+    public void Jump()
+    {
+        if (IsGrounded())
+        {
+            rb.linearVelocity = new Vector2(rb.linearVelocity.x, jumpForce);
+        }
+    }
+
+    // handles the end of the jump. This makes the player slow their upward movement and end the jump early if they tap vs hold the jump key
+    public void JumpEnd()
+    {
+        if (rb.linearVelocity.y > 0f)
+        {
+            rb.linearVelocity = new Vector2(rb.linearVelocity.x, rb.linearVelocity.y * 0.5f);
+        }
+    }
+
+    // enforces the speed limit. Its a school zone after all
+    // has a different speed limit for when in the air vs on the ground, controlled by playerSpeed and maxAirSpeed
+    public void SpeedControl()
+    {
+        Vector2 flatVelocity = new Vector2(rb.linearVelocity.x, 0f);
+
+        if (flatVelocity.magnitude > maxSpeed)
+        {
+            Vector2 limitedVelocity = flatVelocity.normalized * maxSpeed;
+            rb.linearVelocity = new Vector2(limitedVelocity.x, rb.linearVelocity.y);
+        }
+
+        if (!IsGrounded() && flatVelocity.magnitude > maxAirSpeed)
+        {
+            Vector2 limitedVelocity = flatVelocity.normalized * maxAirSpeed;
+            rb.linearVelocity = new Vector2(limitedVelocity.x, rb.linearVelocity.y);
+        }
     }
 }

--- a/Assets/Scripts/PlayerMovement.cs.meta
+++ b/Assets/Scripts/PlayerMovement.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 879ecf2afe6792543b653d9bd87af1b9


### PR DESCRIPTION
Added player movement and input management.

To make this work, you must have some sort of GameManager in the scene with the InputManager script attached. This GameManager Object must be attached to the player's Input Manager field in the Player Movement script. The Ground Layer field must also be set to the layer tag that is associated with the ground. (The ground layer is set to Ground in the prefab)

You can change the players keybinds in the Input Manager. Also have Player Two keybinds in there just in case we have time to implement two players.

The player movement has a bunch of fields that can be changed and tweaked to make movement feel appropriate.
&emsp; Player Speed: how fast the player gains speed
&emsp; Max Speed: the maximum speed a player can move on the ground
&emsp; Max Air Speed: the maximum speed a player can move in the air
&emsp; Jump Force: How high the player can jump
&emsp; Air Multiplier: Affects players movement speed in the air. if < 1, then it will make players slower to change their velocity in mid air. If > 1, then players will be faster to change their velocity in mid air than on the ground.