### PR TITLE
Escape menu open fix

### DIFF
--- a/Assets/Scenes/Levels/Level_1.unity
+++ b/Assets/Scenes/Levels/Level_1.unity
@@ -164,8 +164,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   nextLevelSceneName: Level_2
-  escapeMenuPanel: {fileID: 800610561}
-  quitConfirmationPopup: {fileID: 944921934}
 --- !u!1 &28228060
 GameObject:
   m_ObjectHideFlags: 0
@@ -1001,7 +999,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
+      - m_Target: {fileID: 11082491}
         m_TargetAssemblyTypeName: LevelManager, Assembly-CSharp
         m_MethodName: ConfirmQuitToMainMenu
         m_Mode: 1
@@ -2370,7 +2368,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
+      - m_Target: {fileID: 11082491}
         m_TargetAssemblyTypeName: LevelManager, Assembly-CSharp
         m_MethodName: ResumeGame
         m_Mode: 1
@@ -2709,7 +2707,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
+      - m_Target: {fileID: 11082491}
         m_TargetAssemblyTypeName: LevelManager, Assembly-CSharp
         m_MethodName: LoadMainMenu
         m_Mode: 1
@@ -2995,7 +2993,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
+      - m_Target: {fileID: 11082491}
         m_TargetAssemblyTypeName: LevelManager, Assembly-CSharp
         m_MethodName: RetryLevel
         m_Mode: 1
@@ -4419,7 +4417,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
+      - m_Target: {fileID: 11082491}
         m_TargetAssemblyTypeName: LevelManager, Assembly-CSharp
         m_MethodName: CancelQuitToMainMenu
         m_Mode: 1

--- a/Assets/Scenes/Levels/Level_1.unity
+++ b/Assets/Scenes/Levels/Level_1.unity
@@ -913,6 +913,7 @@ GameObject:
   - component: {fileID: 447119863}
   - component: {fileID: 447119862}
   - component: {fileID: 447119861}
+  - component: {fileID: 447119865}
   m_Layer: 5
   m_Name: YesQuitButton
   m_TagString: Untagged
@@ -1049,6 +1050,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 447119859}
   m_CullTransparentMesh: 1
+--- !u!114 &447119865
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 447119859}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4819b810ff943434abd3cdb582d30a73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &468416974
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2282,6 +2295,7 @@ GameObject:
   - component: {fileID: 1122477835}
   - component: {fileID: 1122477834}
   - component: {fileID: 1122477833}
+  - component: {fileID: 1122477837}
   m_Layer: 5
   m_Name: ResumeButton
   m_TagString: Untagged
@@ -2418,6 +2432,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1122477831}
   m_CullTransparentMesh: 1
+--- !u!114 &1122477837
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1122477831}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4819b810ff943434abd3cdb582d30a73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1264922434
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2621,6 +2647,7 @@ GameObject:
   - component: {fileID: 1293134224}
   - component: {fileID: 1293134223}
   - component: {fileID: 1293134222}
+  - component: {fileID: 1293134226}
   m_Layer: 5
   m_Name: MainMenuButton
   m_TagString: Untagged
@@ -2757,6 +2784,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1293134220}
   m_CullTransparentMesh: 1
+--- !u!114 &1293134226
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1293134220}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4819b810ff943434abd3cdb582d30a73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1304798561
 GameObject:
   m_ObjectHideFlags: 0
@@ -2907,6 +2946,7 @@ GameObject:
   - component: {fileID: 1368891552}
   - component: {fileID: 1368891551}
   - component: {fileID: 1368891550}
+  - component: {fileID: 1368891554}
   m_Layer: 5
   m_Name: RestartButton
   m_TagString: Untagged
@@ -3043,6 +3083,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1368891548}
   m_CullTransparentMesh: 1
+--- !u!114 &1368891554
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1368891548}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4819b810ff943434abd3cdb582d30a73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1387365052
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4331,6 +4383,7 @@ GameObject:
   - component: {fileID: 2134821541}
   - component: {fileID: 2134821540}
   - component: {fileID: 2134821539}
+  - component: {fileID: 2134821543}
   m_Layer: 5
   m_Name: NoQuitButton
   m_TagString: Untagged
@@ -4467,6 +4520,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2134821537}
   m_CullTransparentMesh: 1
+--- !u!114 &2134821543
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2134821537}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4819b810ff943434abd3cdb582d30a73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2141504819
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Levels/Level_1.unity
+++ b/Assets/Scenes/Levels/Level_1.unity
@@ -1352,7 +1352,7 @@ GameObject:
   - component: {fileID: 800610563}
   m_Layer: 5
   m_Name: EscapeMenuPanel
-  m_TagString: Untagged
+  m_TagString: EscapeMenuPanel
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1824,7 +1824,7 @@ GameObject:
   - component: {fileID: 944921936}
   m_Layer: 5
   m_Name: QuitConfirmationPopup
-  m_TagString: Untagged
+  m_TagString: QuitConfirmationPopup
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -3767,6 +3767,74 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1670649108}
   m_CullTransparentMesh: 1
+--- !u!1 &1803078201
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1803078204}
+  - component: {fileID: 1803078203}
+  - component: {fileID: 1803078202}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1803078202
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1803078201}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &1803078203
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1803078201}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &1803078204
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1803078201}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2016116826
 GameObject:
   m_ObjectHideFlags: 0
@@ -4709,3 +4777,4 @@ SceneRoots:
   - {fileID: 1304798565}
   - {fileID: 1391786973}
   - {fileID: 241651021}
+  - {fileID: 1803078204}

--- a/Assets/Scenes/Levels/Level_1.unity
+++ b/Assets/Scenes/Levels/Level_1.unity
@@ -256,6 +256,74 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &166037848
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 166037851}
+  - component: {fileID: 166037850}
+  - component: {fileID: 166037849}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &166037849
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 166037848}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &166037850
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 166037848}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &166037851
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 166037848}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &184556265
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7617,6 +7685,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2134821537}
   m_CullTransparentMesh: 1
+--- !u!114 &2134821543
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2134821537}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4819b810ff943434abd3cdb582d30a73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &691774267767767002
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8389,6 +8469,6 @@ SceneRoots:
   - {fileID: 1304798565}
   - {fileID: 1391786973}
   - {fileID: 241651021}
-  - {fileID: 1803078204}
   - {fileID: 1898567978}
   - {fileID: 373442896}
+  - {fileID: 166037851}

--- a/Assets/Scenes/Levels/Level_2.unity
+++ b/Assets/Scenes/Levels/Level_2.unity
@@ -5586,6 +5586,74 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2106355129080011206, guid: 201cf0d67175abb4a9c6375ddef36dea, type: 3}
   m_PrefabInstance: {fileID: 1331396788}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1374653081
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1374653084}
+  - component: {fileID: 1374653083}
+  - component: {fileID: 1374653082}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1374653082
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1374653081}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &1374653083
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1374653081}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &1374653084
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1374653081}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1388958220
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8485,3 +8553,4 @@ SceneRoots:
   - {fileID: 1707580320}
   - {fileID: 288490173}
   - {fileID: 1273080073}
+  - {fileID: 1374653084}

--- a/Assets/Scenes/Levels/Level_2.unity
+++ b/Assets/Scenes/Levels/Level_2.unity
@@ -839,6 +839,7 @@ GameObject:
   - component: {fileID: 283574649}
   - component: {fileID: 283574648}
   - component: {fileID: 283574647}
+  - component: {fileID: 283574651}
   m_Layer: 5
   m_Name: NoQuitButton
   m_TagString: Untagged
@@ -975,6 +976,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 283574645}
   m_CullTransparentMesh: 1
+--- !u!114 &283574651
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 283574645}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4819b810ff943434abd3cdb582d30a73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &288490171
 GameObject:
   m_ObjectHideFlags: 0
@@ -2071,6 +2084,7 @@ GameObject:
   - component: {fileID: 692192326}
   - component: {fileID: 692192325}
   - component: {fileID: 692192324}
+  - component: {fileID: 692192328}
   m_Layer: 5
   m_Name: ResumeButton
   m_TagString: Untagged
@@ -2207,6 +2221,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 692192322}
   m_CullTransparentMesh: 1
+--- !u!114 &692192328
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 692192322}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4819b810ff943434abd3cdb582d30a73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &750826862
 GameObject:
   m_ObjectHideFlags: 0
@@ -2987,6 +3013,7 @@ GameObject:
   - component: {fileID: 913919667}
   - component: {fileID: 913919666}
   - component: {fileID: 913919665}
+  - component: {fileID: 913919669}
   m_Layer: 5
   m_Name: YesQuitButton
   m_TagString: Untagged
@@ -3123,6 +3150,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 913919663}
   m_CullTransparentMesh: 1
+--- !u!114 &913919669
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 913919663}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4819b810ff943434abd3cdb582d30a73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &946130055
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3600,8 +3639,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   nextLevelSceneName: Level_3
-  escapeMenuPanel: {fileID: 1734836424}
-  quitConfirmationPopup: {fileID: 2098587046}
 --- !u!1 &1050424657
 GameObject:
   m_ObjectHideFlags: 0
@@ -5823,6 +5860,7 @@ GameObject:
   - component: {fileID: 1413059776}
   - component: {fileID: 1413059775}
   - component: {fileID: 1413059774}
+  - component: {fileID: 1413059778}
   m_Layer: 5
   m_Name: RestartButton
   m_TagString: Untagged
@@ -5959,6 +5997,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1413059772}
   m_CullTransparentMesh: 1
+--- !u!114 &1413059778
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1413059772}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4819b810ff943434abd3cdb582d30a73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1420613363
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6950,6 +7000,7 @@ GameObject:
   - component: {fileID: 1586253618}
   - component: {fileID: 1586253617}
   - component: {fileID: 1586253616}
+  - component: {fileID: 1586253620}
   m_Layer: 5
   m_Name: MainMenuButton
   m_TagString: Untagged
@@ -7086,6 +7137,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1586253614}
   m_CullTransparentMesh: 1
+--- !u!114 &1586253620
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1586253614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4819b810ff943434abd3cdb582d30a73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1594176074
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Levels/Level_3.unity
+++ b/Assets/Scenes/Levels/Level_3.unity
@@ -562,6 +562,7 @@ GameObject:
   - component: {fileID: 196288493}
   - component: {fileID: 196288492}
   - component: {fileID: 196288491}
+  - component: {fileID: 196288495}
   m_Layer: 5
   m_Name: YesQuitButton
   m_TagString: Untagged
@@ -698,6 +699,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 196288489}
   m_CullTransparentMesh: 1
+--- !u!114 &196288495
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 196288489}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4819b810ff943434abd3cdb582d30a73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &197826942
 GameObject:
   m_ObjectHideFlags: 0
@@ -843,6 +856,7 @@ GameObject:
   - component: {fileID: 211843211}
   - component: {fileID: 211843210}
   - component: {fileID: 211843209}
+  - component: {fileID: 211843213}
   m_Layer: 5
   m_Name: RestartButton
   m_TagString: Untagged
@@ -979,6 +993,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 211843207}
   m_CullTransparentMesh: 1
+--- !u!114 &211843213
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 211843207}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4819b810ff943434abd3cdb582d30a73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &212531280
 GameObject:
   m_ObjectHideFlags: 0
@@ -2027,8 +2053,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   nextLevelSceneName: Level_4
-  escapeMenuPanel: {fileID: 149857294}
-  quitConfirmationPopup: {fileID: 212531280}
 --- !u!1 &734482657
 GameObject:
   m_ObjectHideFlags: 0
@@ -2677,6 +2701,7 @@ GameObject:
   - component: {fileID: 1069160551}
   - component: {fileID: 1069160550}
   - component: {fileID: 1069160549}
+  - component: {fileID: 1069160553}
   m_Layer: 5
   m_Name: NoQuitButton
   m_TagString: Untagged
@@ -2813,6 +2838,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1069160547}
   m_CullTransparentMesh: 1
+--- !u!114 &1069160553
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1069160547}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4819b810ff943434abd3cdb582d30a73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1126006881
 GameObject:
   m_ObjectHideFlags: 0
@@ -3230,6 +3267,7 @@ GameObject:
   - component: {fileID: 1346536384}
   - component: {fileID: 1346536383}
   - component: {fileID: 1346536382}
+  - component: {fileID: 1346536386}
   m_Layer: 5
   m_Name: MainMenuButton
   m_TagString: Untagged
@@ -3366,6 +3404,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1346536380}
   m_CullTransparentMesh: 1
+--- !u!114 &1346536386
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1346536380}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4819b810ff943434abd3cdb582d30a73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1350897967
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4526,6 +4576,7 @@ GameObject:
   - component: {fileID: 1728763739}
   - component: {fileID: 1728763738}
   - component: {fileID: 1728763737}
+  - component: {fileID: 1728763741}
   m_Layer: 5
   m_Name: ResumeButton
   m_TagString: Untagged
@@ -4662,6 +4713,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1728763735}
   m_CullTransparentMesh: 1
+--- !u!114 &1728763741
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1728763735}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4819b810ff943434abd3cdb582d30a73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1741486041
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Levels/Level_3.unity
+++ b/Assets/Scenes/Levels/Level_3.unity
@@ -5151,6 +5151,74 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2118469280
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2118469283}
+  - component: {fileID: 2118469282}
+  - component: {fileID: 2118469281}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2118469281
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2118469280}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &2118469282
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2118469280}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &2118469283
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2118469280}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2146256226
 GameObject:
   m_ObjectHideFlags: 0
@@ -5405,3 +5473,4 @@ SceneRoots:
   - {fileID: 741726491}
   - {fileID: 1360181087}
   - {fileID: 1628215024}
+  - {fileID: 2118469283}

--- a/Assets/Scenes/Levels/Level_4.unity
+++ b/Assets/Scenes/Levels/Level_4.unity
@@ -1597,6 +1597,74 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8851817347107172724, guid: 0f431fcc71c171248b073520df084f63, type: 3}
   m_PrefabInstance: {fileID: 662356256}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &618357447
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 618357450}
+  - component: {fileID: 618357449}
+  - component: {fileID: 618357448}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &618357448
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 618357447}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &618357449
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 618357447}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &618357450
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 618357447}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &636905182
 GameObject:
   m_ObjectHideFlags: 0
@@ -7577,3 +7645,4 @@ SceneRoots:
   - {fileID: 606960782}
   - {fileID: 246960986}
   - {fileID: 560715222}
+  - {fileID: 618357450}

--- a/Assets/Scenes/Levels/Level_4.unity
+++ b/Assets/Scenes/Levels/Level_4.unity
@@ -364,6 +364,7 @@ GameObject:
   - component: {fileID: 195462256}
   - component: {fileID: 195462255}
   - component: {fileID: 195462254}
+  - component: {fileID: 195462258}
   m_Layer: 5
   m_Name: YesQuitButton
   m_TagString: Untagged
@@ -500,6 +501,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 195462252}
   m_CullTransparentMesh: 1
+--- !u!114 &195462258
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 195462252}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4819b810ff943434abd3cdb582d30a73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &246960984
 GameObject:
   m_ObjectHideFlags: 0
@@ -1814,6 +1827,7 @@ GameObject:
   - component: {fileID: 651670721}
   - component: {fileID: 651670720}
   - component: {fileID: 651670719}
+  - component: {fileID: 651670723}
   m_Layer: 5
   m_Name: NoQuitButton
   m_TagString: Untagged
@@ -1950,6 +1964,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 651670717}
   m_CullTransparentMesh: 1
+--- !u!114 &651670723
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 651670717}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4819b810ff943434abd3cdb582d30a73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &662356256
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2390,6 +2416,7 @@ GameObject:
   - component: {fileID: 832009983}
   - component: {fileID: 832009982}
   - component: {fileID: 832009981}
+  - component: {fileID: 832009985}
   m_Layer: 5
   m_Name: RestartButton
   m_TagString: Untagged
@@ -2526,6 +2553,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 832009979}
   m_CullTransparentMesh: 1
+--- !u!114 &832009985
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 832009979}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4819b810ff943434abd3cdb582d30a73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &917670644
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2886,8 +2925,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   nextLevelSceneName: MainMenu
-  escapeMenuPanel: {fileID: 1168785508}
-  quitConfirmationPopup: {fileID: 1675038982}
 --- !u!1001 &1121749608
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3424,6 +3461,7 @@ GameObject:
   - component: {fileID: 1569832109}
   - component: {fileID: 1569832108}
   - component: {fileID: 1569832107}
+  - component: {fileID: 1569832111}
   m_Layer: 5
   m_Name: ResumeButton
   m_TagString: Untagged
@@ -3560,6 +3598,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1569832105}
   m_CullTransparentMesh: 1
+--- !u!114 &1569832111
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1569832105}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4819b810ff943434abd3cdb582d30a73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1635996344
 GameObject:
   m_ObjectHideFlags: 0
@@ -3613,6 +3663,7 @@ GameObject:
   - component: {fileID: 1671663790}
   - component: {fileID: 1671663789}
   - component: {fileID: 1671663788}
+  - component: {fileID: 1671663792}
   m_Layer: 5
   m_Name: MainMenuButton
   m_TagString: Untagged
@@ -3749,6 +3800,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1671663786}
   m_CullTransparentMesh: 1
+--- !u!114 &1671663792
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1671663786}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4819b810ff943434abd3cdb582d30a73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1675038982
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/ButtonManager.cs
+++ b/Assets/Scripts/ButtonManager.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+// This script is for buttons that use scripts from the LevelManager. 
+// To use this script, ensure that the script the button uses is in LevelManager. Then, attach this to the button, and add add
+// another else/if below in the OnClickEvent() function that references the button's name to the expected button name for the script. Then
+// just call "script.[your script here]();"
+// 
+// this script ensures that the buttons are always referencing the LevelManager.
+// without this script, the buttons will reference nothing, since they reference a Destroyed Singleton when loading a new level.
+public class ButtonManager : MonoBehaviour
+{
+    private Button button;
+    private LevelManager script;
+
+    private void Awake()
+    {
+        button = GetComponent<Button>();
+        script = GameObject.Find("LevelManager").GetComponent<LevelManager>();
+
+        button.onClick.AddListener(OnClickEvent);
+    }
+
+    // this currently hard-codes the types of buttons the menu expects and attaches the expected script to it. This could probably be handled differently
+    // to enhance modularity, but I can't really think of a way to do it right now lol.
+    private void OnClickEvent()
+    {
+        if (this.name == "ResumeButton")
+            script.ResumeGame();
+        else if (this.name == "RestartButton")
+            script.RetryLevel();
+        else if (this.name == "MainMenuButton")
+            script.LoadMainMenu();
+        else if (this.name == "YesQuitButton")
+            script.ConfirmQuitToMainMenu();
+        else if (this.name == "NoQuitButton")
+            script.CancelQuitToMainMenu();
+    }
+}

--- a/Assets/Scripts/ButtonManager.cs.meta
+++ b/Assets/Scripts/ButtonManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4819b810ff943434abd3cdb582d30a73

--- a/Assets/Scripts/EnvironmentMechanics/CrackingPlatform.cs
+++ b/Assets/Scripts/EnvironmentMechanics/CrackingPlatform.cs
@@ -25,6 +25,12 @@ public class CrackingPlatform : MonoBehaviour
 
     void Update()
     {
+        //pause everything if the pause menu is active
+        if (LevelManager.Instance != null && LevelManager.Instance.IsPaused())
+        {
+            return;
+        }
+        
         animator.SetBool("isPlayerOn", isPlayerOn);
         animator.SetFloat("AnimSpeed", crackSpeed);
 

--- a/Assets/Scripts/EnvironmentMechanics/PilingSnow.cs
+++ b/Assets/Scripts/EnvironmentMechanics/PilingSnow.cs
@@ -6,6 +6,12 @@ public class PilingSnow : MonoBehaviour
 
     void Update()
     {
+        //pause everything if the pause menu is active
+        if (LevelManager.Instance != null && LevelManager.Instance.IsPaused())
+        {
+            return;
+        }
+        
         transform.position += Vector3.up * snowSpeed * Time.deltaTime;
     }
 

--- a/Assets/Scripts/FuzzyEnemy.cs
+++ b/Assets/Scripts/FuzzyEnemy.cs
@@ -19,6 +19,12 @@ public class FuzzyEnemy : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
+        //pause everything if the pause menu is active
+        if (LevelManager.Instance != null && LevelManager.Instance.IsPaused())
+        {
+            return;
+        }
+
         animator.SetBool("isHurt", isHurt);
         move(moveVector);
     }

--- a/Assets/Scripts/InputManager.cs
+++ b/Assets/Scripts/InputManager.cs
@@ -20,6 +20,12 @@ public class InputManager : MonoBehaviour
 
     void Update()
     {
+        //pause everything if the pause menu is active
+        if (LevelManager.Instance != null && LevelManager.Instance.IsPaused())
+        {
+            return;
+        }
+
         Vector2 inputVector = new Vector2();
 
         if (Input.GetKey(playerOneLeft))

--- a/Assets/Scripts/LevelManager.cs
+++ b/Assets/Scripts/LevelManager.cs
@@ -37,10 +37,12 @@ public class LevelManager : MonoBehaviour
     {
         yield return null;
 
+        for (int i = 0; i < 3; i++) yield return null;
+
         var canvas = GameObject.Find("EscapeCanvas");
         if (canvas == null)
         {
-            Debug.LogWarning("EscapeCanvas not found.");
+            Debug.Log("EscapeCanvas not found.");
             yield break;
         }
 
@@ -55,7 +57,7 @@ public class LevelManager : MonoBehaviour
         }
         else
         {
-            Debug.LogWarning("EscapeMenuPanel not found or missing MenuNavigator.");
+            Debug.Log("EscapeMenuPanel not found or missing MenuNavigator.");
         }
     }
 

--- a/Assets/Scripts/LevelManager.cs
+++ b/Assets/Scripts/LevelManager.cs
@@ -27,6 +27,10 @@ public class LevelManager : MonoBehaviour
         }
     }
 
+    public bool IsPaused()
+    {
+        return isPaused;
+    }
 
     private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
     {
@@ -120,6 +124,7 @@ public class LevelManager : MonoBehaviour
 
     public void ConfirmQuitToMainMenu()
     {
+        isPaused = false;
         Time.timeScale = 1f;
         SceneManager.LoadScene("MainMenu");
     }
@@ -180,6 +185,7 @@ public class LevelManager : MonoBehaviour
 
     public void RetryLevel()
     {
+        isPaused = false;
         Time.timeScale = 1f;
         SceneManager.LoadScene(SceneManager.GetActiveScene().name);
     }

--- a/Assets/Scripts/LevelManager.cs
+++ b/Assets/Scripts/LevelManager.cs
@@ -1,12 +1,14 @@
 using System.Collections;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using UnityEngine.EventSystems;
 
 public class LevelManager : MonoBehaviour
 {
     [SerializeField] private string nextLevelSceneName;
-    [SerializeField] private GameObject escapeMenuPanel;
-    [SerializeField] private GameObject quitConfirmationPopup;
+    private GameObject escapeMenuPanel;
+    private GameObject quitConfirmationPopup;
+    private MenuNavigator menuNavigator;
 
     public static LevelManager Instance;
     private bool isPaused = false;
@@ -17,6 +19,7 @@ public class LevelManager : MonoBehaviour
         {
             Instance = this;
             DontDestroyOnLoad(gameObject);
+            SceneManager.sceneLoaded += OnSceneLoaded;
         }
         else
         {
@@ -24,13 +27,45 @@ public class LevelManager : MonoBehaviour
         }
     }
 
-    void Start()
+
+    private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
     {
+        StartCoroutine(RebindUIElements());
+    }
+
+    private IEnumerator RebindUIElements()
+    {
+        yield return null;
+
+        var canvas = GameObject.Find("EscapeCanvas");
+        if (canvas == null)
+        {
+            Debug.LogWarning("EscapeCanvas not found.");
+            yield break;
+        }
+
+        escapeMenuPanel = canvas.transform.Find("EscapeMenuPanel")?.gameObject;
+        quitConfirmationPopup = canvas.transform.Find("QuitConfirmationPopup")?.gameObject;
+
         if (escapeMenuPanel != null)
         {
             escapeMenuPanel.SetActive(false);
+            menuNavigator = escapeMenuPanel.GetComponent<MenuNavigator>();
+            Debug.Log("EscapeMenuPanel and MenuNavigator linked.");
+        }
+        else
+        {
+            Debug.LogWarning("EscapeMenuPanel not found or missing MenuNavigator.");
         }
     }
+
+    // void Start()
+    // {
+    //     if (escapeMenuPanel != null)
+    //     {
+    //         escapeMenuPanel.SetActive(false);
+    //     }
+    // }
 
     void Update()
     {
@@ -48,6 +83,15 @@ public class LevelManager : MonoBehaviour
         if (escapeMenuPanel != null)
         {
             escapeMenuPanel.SetActive(isPaused);
+
+            if (isPaused)
+            {
+                menuNavigator?.ResetSelection();
+            }
+            else
+            {
+                EventSystem.current.SetSelectedGameObject(null);
+            }
         }
 
         Time.timeScale = isPaused ? 0f : 1f;
@@ -65,7 +109,10 @@ public class LevelManager : MonoBehaviour
         if (quitConfirmationPopup != null)
         {
             quitConfirmationPopup.SetActive(true);
-            escapeMenuPanel.SetActive(false);
+            escapeMenuPanel?.SetActive(false);
+
+            var quitNav = quitConfirmationPopup.GetComponent<MenuNavigator>();
+            quitNav?.ResetSelection();
         }
     }
 
@@ -94,10 +141,22 @@ public class LevelManager : MonoBehaviour
         string next = "";
 
         // Manually define next level logic
-        if (current == "Level_1") next = "Level_2";
-        else if (current == "Level_2") next = "Level_3";
-        else if (current == "Level_3") next = "Level_4";
-        else next = "MainMenu";
+        if (current == "Level_1")
+        {
+            next = "Level_2";
+        }
+        else if (current == "Level_2")
+        {
+            next = "Level_3";
+        }
+        else if (current == "Level_3")
+        {
+            next = "Level_4";
+        }
+        else
+        {
+            next = "MainMenu";
+        }
 
         LevelTracker.Instance.currentLevelScene = current;
         LevelTracker.Instance.nextLevelScene = next;

--- a/Assets/Scripts/MenuNavigator.cs
+++ b/Assets/Scripts/MenuNavigator.cs
@@ -14,13 +14,13 @@ public class MenuNavigator : MonoBehaviour
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
     {
-        SelectButton(selectedIndex);
+        ResetSelection();
     }
 
     // Update is called once per frame
     void Update()
     {
-        if (!gameObject.activeInHierarchy)
+        if (!gameObject.activeInHierarchy || buttons.Count == 0)
         {
             return;
         }
@@ -60,15 +60,19 @@ public class MenuNavigator : MonoBehaviour
 
     private void SelectButton(int index)
     {
+        EventSystem.current.SetSelectedGameObject(null); // clear the old EventSystem stuff
         EventSystem.current.SetSelectedGameObject(buttons[index].gameObject);
     }
-    
+
     public void ResetSelection()
     {
-        if (buttons.Count == 0) return;
-
         selectedIndex = 0;
-        EventSystem.current.SetSelectedGameObject(null);
+        //EventSystem.current.SetSelectedGameObject(null); // clear old EventSystem stuff 
         SelectButton(selectedIndex);
+    }
+
+    void OnEnable()
+    {
+        ResetSelection();
     }
 }

--- a/Assets/Scripts/MenuNavigator.cs
+++ b/Assets/Scripts/MenuNavigator.cs
@@ -40,7 +40,7 @@ public class MenuNavigator : MonoBehaviour
         {
             selectedIndex = (selectedIndex + 1 + buttons.Count) % buttons.Count;
             SelectButton(selectedIndex);
-            
+
             if (switchButtonAudio != null)
             {
                 switchButtonAudio.Play();
@@ -61,5 +61,14 @@ public class MenuNavigator : MonoBehaviour
     private void SelectButton(int index)
     {
         EventSystem.current.SetSelectedGameObject(buttons[index].gameObject);
+    }
+    
+    public void ResetSelection()
+    {
+        if (buttons.Count == 0) return;
+
+        selectedIndex = 0;
+        EventSystem.current.SetSelectedGameObject(null);
+        SelectButton(selectedIndex);
     }
 }

--- a/Assets/Scripts/MovingPlatform.cs
+++ b/Assets/Scripts/MovingPlatform.cs
@@ -19,6 +19,12 @@ public class MovingPlatform : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
+        //pause everything if the pause menu is active
+        if (LevelManager.Instance != null && LevelManager.Instance.IsPaused())
+        {
+            return;
+        }
+
         if (!sprite.isVisible)
         {//if the object is invisible, flip it's ovement direction
 

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -32,7 +32,13 @@ public class PlayerMovement : MonoBehaviour
 
     // update ensures that the player doesn't go above the speed limit and handles flipping the character for sprite stuff
     void Update()
-    {
+    {        
+        if (LevelManager.Instance != null && LevelManager.Instance.IsPaused())
+        {
+            rb.linearVelocity = Vector2.zero;
+            return;
+        }
+
         SpeedControl();
         Flip();
     }
@@ -40,6 +46,12 @@ public class PlayerMovement : MonoBehaviour
     // adds force to the rigidbody to move the character. Applies a different speed if the character is in the air
     public void MovePlayer(Vector2 input)
     {
+        //pause player if pause menu is activated
+        if (LevelManager.Instance != null && LevelManager.Instance.IsPaused())
+        {
+            return;
+        }
+
         if (IsGrounded())
             rb.AddForce(input.normalized * playerSpeed, ForceMode2D.Force);
 
@@ -70,6 +82,12 @@ public class PlayerMovement : MonoBehaviour
     // handles jumps. makes the y component equal to the jump force
     public void Jump()
     {
+        //pause player if pause menu is activated
+        if (LevelManager.Instance != null && LevelManager.Instance.IsPaused())
+        {
+            return;
+        }
+
         if (IsGrounded())
         {
             rb.linearVelocity = new Vector2(rb.linearVelocity.x, jumpForce);
@@ -79,6 +97,12 @@ public class PlayerMovement : MonoBehaviour
     // handles the end of the jump. This makes the player slow their upward movement and end the jump early if they tap vs hold the jump key
     public void JumpEnd()
     {
+        //pause player if pause menu is activated
+        if (LevelManager.Instance != null && LevelManager.Instance.IsPaused())
+        {
+            return;
+        }
+
         if (rb.linearVelocity.y > 0f)
         {
             rb.linearVelocity = new Vector2(rb.linearVelocity.x, rb.linearVelocity.y * 0.5f);

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -71,7 +71,7 @@ public class PlayerMovement : MonoBehaviour
             rb.AddForce(input.normalized * playerSpeed, ForceMode2D.Force);
             animator.SetFloat("Speed", Mathf.Abs(rb.linearVelocity.x));
         }
-            
+
 
         else if (!IsGrounded())
             rb.AddForce(input.normalized * playerSpeed * airMultiplier, ForceMode2D.Force);

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -8,6 +8,8 @@ TagManager:
   - Enemy
   - Moving_Platform
   - Block
+  - EscapeMenuPanel
+  - QuitConfirmationPopup
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Fixing all bugs related to the pause/escape menu:
- Escape menu would not open
- Clicking button does not do anything
- Game not freezing when escape menu is active


As objects with movement are added to each level, their scripts must have a check to see whether the pause menu is active, like this
`if (LevelManager.Instance != null && LevelManager.Instance.IsPaused())
{
     return;
}`

If this is not included, the object will not pause while menu is active.